### PR TITLE
Parse only the body element

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'screens/home_screen.dart';
+import 'config.dart';
 
 void main() {
   runApp(const MyApp());

--- a/lib/services/url_fetcher.dart
+++ b/lib/services/url_fetcher.dart
@@ -3,24 +3,35 @@
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
+import 'package:html/parser.dart' as html_parser;
 import '../../config.dart';
 
 class UrlFetcherService {
-  // Singleton pattern to ensure only one instance
   static final UrlFetcherService _instance = UrlFetcherService._internal();
   factory UrlFetcherService() => _instance;
   UrlFetcherService._internal();
 
-  // Fetch content from URL
   Future<String> fetchReleaseNotes(String version) async {
     try {
       final url = DocsConfig.getReleaseNotesUrl(version);
-      final response = await http
-          .get(Uri.parse(url))
-          .timeout(Duration(seconds: AppConfig.requestTimeout));
+
+      if (AppConfig.debugMode) {
+        print('Fetching from URL: $url');
+      }
+
+      final response = await http.get(
+        Uri.parse(url),
+        headers: {
+          'Accept': 'text/html,application/xhtml+xml,application/xml',
+          'User-Agent': 'Mozilla/5.0 Flutter/1.0',
+        },
+      ).timeout(Duration(seconds: AppConfig.requestTimeout));
 
       if (response.statusCode == 200) {
-        return response.body;
+        // Parse the HTML content and extract the body
+        final document = html_parser.parse(response.body);
+        final bodyContent = document.body?.text ?? '';
+        return bodyContent;
       } else {
         throw HttpException(
             'Failed to load release notes: ${response.statusCode}');
@@ -32,8 +43,4 @@ class UrlFetcherService {
       rethrow;
     }
   }
-
-  // You might want to add more methods here later, such as:
-  // Future<String> fetchPlainText(String markdown) async {...}
-  // Future<String> fetchSummary(String content) async {...}
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -75,6 +83,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  html:
+    dependency: "direct main"
+    description:
+      name: html
+      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.5"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   http: ^1.2.2
+  html: ^0.15.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and maintainability of the codebase. The most important changes involve adding HTML parsing capabilities, enhancing the URL fetching service, and updating dependencies.

Enhancements to URL fetching service:

* [`lib/services/url_fetcher.dart`](diffhunk://#diff-4a3741c7d917fb031f2c1c76fdbd8c6c32e303379d3135b0bc4c4329c8d82854R6-R34): Added HTML parsing to extract the body content from fetched HTML documents using the `html_parser` package. This includes adding appropriate headers to the HTTP request and logging the URL when in debug mode.
* [`lib/services/url_fetcher.dart`](diffhunk://#diff-4a3741c7d917fb031f2c1c76fdbd8c6c32e303379d3135b0bc4c4329c8d82854L35-L38): Removed unnecessary comments and unused methods to clean up the code.

Dependency updates:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R38): Added the `html` package as a dependency to enable HTML parsing.

Configuration and imports:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R3): Imported the `config.dart` file to ensure configuration settings are available.