### PR TITLE
Feature/markdown plaintext views

### DIFF
--- a/lib/models/release_notes_model.dart
+++ b/lib/models/release_notes_model.dart
@@ -1,0 +1,126 @@
+// lib/models/release_notes_model.dart
+
+import 'package:html/parser.dart' as html_parser;
+import 'package:html/dom.dart';
+
+String normalizeTitle(String title) {
+  // Implement title normalization similar to Python's normalize_title
+  return title.replaceAll('¶', '').trim().capitalize();
+}
+
+extension StringExtension on String {
+  String capitalize() {
+    if (isEmpty) return this;
+    return '${this[0].toUpperCase()}${substring(1)}';
+  }
+}
+
+class DetailSection {
+  final Element soup;
+  late String url;
+  String? title;
+  List<Map<String, String>> subSections = [];
+
+  DetailSection({required this.soup, required this.url}) {
+    parseSubSections();
+  }
+
+  void parseSubSections() {
+    final h3Element = soup.querySelector('h3');
+    if (h3Element != null) {
+      title = normalizeTitle(h3Element.text);
+    }
+
+    final sectionId = soup.attributes['id'];
+    if (sectionId != null) {
+      url = '$url#$sectionId';
+    }
+  }
+
+  Map<String, String> getSubSection(int index) {
+    return subSections[index];
+  }
+}
+
+class Section {
+  final Element soup;
+  final String url;
+  String? title;
+  List<DetailSection> subSections = [];
+
+  Section({required this.soup, required this.url}) {
+    parseSubSections();
+  }
+
+  void parseSubSections() {
+    final h2Element = soup.querySelector('h2');
+    if (h2Element != null) {
+      title = normalizeTitle(h2Element.text);
+    }
+
+    final subSectionsSoup = soup.querySelectorAll('section');
+    for (var subSection in subSectionsSoup) {
+      subSections.add(DetailSection(soup: subSection, url: url));
+    }
+  }
+
+  DetailSection getSubSection(int index) {
+    return subSections[index];
+  }
+}
+
+class ReleaseNotesModel {
+  final String url;
+  List<Section> optionalSections = [];
+  List<Section> sections = [];
+  String? mainTitle;
+  String? mainUrl;
+  late Element soup;
+
+  ReleaseNotesModel({required this.url});
+
+  Future<void> initialize(String htmlContent) async {
+    soup = html_parser.parse(htmlContent).documentElement!;
+    await parseSections();
+  }
+
+  Future<void> parseSections() async {
+    final main = soup.querySelector('main[id="main"][role="main"]');
+    if (main == null) return;
+
+    final mainSection = main.querySelector('section');
+    if (mainSection == null) return;
+
+    final mainHeading = mainSection.querySelector('h1');
+    if (mainHeading != null) {
+      mainTitle = normalizeTitle(mainHeading.text);
+
+      final anchor = mainHeading.querySelector('a');
+      if (anchor != null && anchor.attributes.containsKey('href')) {
+        final href = anchor.attributes['href']!.replaceAll('#', '').trim();
+        mainUrl = '$url#$href';
+      }
+    }
+
+    final sectionsSoup = mainSection.querySelectorAll('section');
+    for (var section in sectionsSoup) {
+      final heading = section.querySelector('h2');
+      if (heading != null) {
+        final sectionTitle = heading.text;
+        if (sectionTitle.toLowerCase().contains("what's new")) {
+          optionalSections.add(Section(soup: section, url: url));
+        } else {
+          sections.add(Section(soup: section, url: url));
+        }
+      }
+    }
+  }
+
+  Section getSection(int index) {
+    return sections[index];
+  }
+
+  Section getOptionalSection(int index) {
+    return optionalSections[index];
+  }
+}

--- a/lib/screens/markdown_screen.dart
+++ b/lib/screens/markdown_screen.dart
@@ -12,6 +12,8 @@ class MarkdownScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('MarkdownScreen build');
+    print(content);
     return Scaffold(
       appBar: AppBar(
         title: Text('Markdown View - $releaseVersion'),

--- a/lib/screens/markdown_screen.dart
+++ b/lib/screens/markdown_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class MarkdownScreen extends StatelessWidget {
+  final String content;
+  final String releaseVersion;
+
+  const MarkdownScreen({
+    Key? key,
+    required this.content,
+    required this.releaseVersion,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Markdown View - $releaseVersion'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Text(content),
+      ),
+    );
+  }
+}

--- a/lib/screens/plain_text_screen.dart
+++ b/lib/screens/plain_text_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class PlainTextScreen extends StatelessWidget {
+  final String content;
+  final String releaseVersion;
+
+  const PlainTextScreen({
+    Key? key,
+    required this.content,
+    required this.releaseVersion,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Plain Text View - $releaseVersion'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Text(content),
+      ),
+    );
+  }
+}

--- a/lib/screens/plain_text_screen.dart
+++ b/lib/screens/plain_text_screen.dart
@@ -12,6 +12,8 @@ class PlainTextScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('PlainTextScreen build');
+    print(content);
     return Scaffold(
       appBar: AppBar(
         title: Text('Plain Text View - $releaseVersion'),

--- a/lib/services/url_fetcher.dart
+++ b/lib/services/url_fetcher.dart
@@ -1,17 +1,16 @@
 // lib/services/url_fetcher.dart
 
 import 'dart:io';
-
 import 'package:http/http.dart' as http;
-import 'package:html/parser.dart' as html_parser;
-import '../../config.dart';
+import '../models/release_notes_model.dart';
+import '../config.dart';
 
 class UrlFetcherService {
   static final UrlFetcherService _instance = UrlFetcherService._internal();
   factory UrlFetcherService() => _instance;
   UrlFetcherService._internal();
 
-  Future<String> fetchReleaseNotes(String version) async {
+  Future<ReleaseNotesModel> fetchReleaseNotes(String version) async {
     try {
       final url = DocsConfig.getReleaseNotesUrl(version);
 
@@ -28,10 +27,9 @@ class UrlFetcherService {
       ).timeout(Duration(seconds: AppConfig.requestTimeout));
 
       if (response.statusCode == 200) {
-        // Parse the HTML content and extract the body
-        final document = html_parser.parse(response.body);
-        final bodyContent = document.body?.text ?? '';
-        return bodyContent;
+        final model = ReleaseNotesModel(url: url);
+        await model.initialize(response.body);
+        return model;
       } else {
         throw HttpException(
             'Failed to load release notes: ${response.statusCode}');


### PR DESCRIPTION
This pull request introduces several new features and refactors existing code to improve the functionality and organization of the release notes model and the home screen. The most important changes include the addition of a new `ReleaseNotesModel` class, updates to the home screen to navigate to new screens, and the creation of new screens for displaying release notes in Markdown and plain text formats.

### New Features:
* **Release Notes Model**:
  * Added `ReleaseNotesModel` class to parse and manage release notes from HTML content. This includes new classes `Section` and `DetailSection` to handle different sections and subsections of the release notes.

* **New Screens**:
  * Added `MarkdownScreen` and `PlainTextScreen` to display release notes in Markdown and plain text formats, respectively. [[1]](diffhunk://#diff-8f41b76a20c8e8cf632cef2bb8c0514223c9ea56683721af78cfcfa3422fc775R1-R31) [[2]](diffhunk://#diff-c553abf24cdb0c99228249a7018066325883d4c89ff83259a17618b50d3778baR1-R31)

### Home Screen Updates:
* **Navigation and Loading**:
  * Updated `HomeScreen` to navigate to `MarkdownScreen` or `PlainTextScreen` based on user selection and show loading and error dialogs during the fetch process. Removed unused text controllers and error message handling. [[1]](diffhunk://#diff-935e56a557f0ab902a679f47de66345d9f47058bccb96f870e6383d19e2c86ddL3-R7) [[2]](diffhunk://#diff-935e56a557f0ab902a679f47de66345d9f47058bccb96f870e6383d19e2c86ddL18-R78) [[3]](diffhunk://#diff-935e56a557f0ab902a679f47de66345d9f47058bccb96f870e6383d19e2c86ddL80-R117)

### Service Updates:
* **URL Fetcher Service**:
  * Modified `UrlFetcherService` to return a `ReleaseNotesModel` instead of raw HTML content, integrating the new model class for better structure and parsing. [[1]](diffhunk://#diff-4a3741c7d917fb031f2c1c76fdbd8c6c32e303379d3135b0bc4c4329c8d82854L4-R13) [[2]](diffhunk://#diff-4a3741c7d917fb031f2c1c76fdbd8c6c32e303379d3135b0bc4c4329c8d82854L31-R32)