### PR TITLE
Add the markdown and plain text conversion methods to the ReleaseNote…

### DIFF
--- a/lib/models/release_notes_model.dart
+++ b/lib/models/release_notes_model.dart
@@ -123,4 +123,84 @@ class ReleaseNotesModel {
   Section getOptionalSection(int index) {
     return optionalSections[index];
   }
+
+  // Add these methods to your ReleaseNotesModel class
+
+  String toMarkdown() {
+    StringBuffer buffer = StringBuffer();
+
+    // Main title and initial instructions
+    if (mainTitle != null) {
+      buffer.writeln('# $mainTitle');
+      buffer.writeln();
+      buffer.writeln(
+          'Add a link to the commit or file for each consideration if you made any code changes.');
+      buffer.writeln();
+      buffer.writeln('## Code reviewing a consideration.');
+      buffer.writeln();
+      buffer.writeln(
+          'Use the tick box to indicate a consideration has been code reviewed as OK');
+      buffer.writeln();
+    }
+
+    // What's New sections (optional sections)
+    for (var section in optionalSections) {
+      if (section.title != null) {
+        buffer.writeln('### ${section.title}');
+        for (var subSection in section.subSections) {
+          if (subSection.title != null) {
+            buffer.writeln('  - [ ] [${subSection.title}](${subSection.url})');
+          }
+        }
+        buffer.writeln();
+      }
+    }
+
+    // Other sections
+    for (var section in sections) {
+      if (section.title != null) {
+        buffer.writeln('### ${section.title}');
+        for (var subSection in section.subSections) {
+          if (subSection.title != null) {
+            buffer.writeln('  - [ ] [${subSection.title}](${subSection.url})');
+          }
+        }
+        buffer.writeln();
+      }
+    }
+
+    return buffer.toString();
+  }
+
+  String toPlainText() {
+    StringBuffer buffer = StringBuffer();
+
+    // What's New sections (optional sections)
+    for (var section in optionalSections) {
+      buffer.writeln('====================================\n');
+      if (section.title != null) {
+        buffer.writeln('${section.title}\n${section.url}\n');
+        for (var subSection in section.subSections) {
+          if (subSection.title != null) {
+            buffer.writeln('  ${subSection.title}\n  ${subSection.url}\n');
+          }
+        }
+      }
+    }
+
+    // Other sections
+    for (var section in sections) {
+      buffer.writeln('====================================\n');
+      if (section.title != null) {
+        buffer.writeln('${section.title}\n${section.url}\n');
+        for (var subSection in section.subSections) {
+          if (subSection.title != null) {
+            buffer.writeln('  ${subSection.title}\n  ${subSection.url}\n');
+          }
+        }
+      }
+    }
+
+    return buffer.toString();
+  }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -33,11 +33,13 @@ class _HomeScreenState extends State<HomeScreen> {
     );
 
     try {
-      final content =
-          await _urlFetcher.fetchReleaseNotes(_selectedReleasePage!);
+      final model = await _urlFetcher.fetchReleaseNotes(_selectedReleasePage!);
 
       // Pop the loading dialog
       Navigator.pop(context);
+
+      final formattedContent =
+          isMarkdown ? model.toMarkdown() : model.toPlainText();
 
       // Navigate to the appropriate screen
       Navigator.push(
@@ -45,11 +47,11 @@ class _HomeScreenState extends State<HomeScreen> {
         MaterialPageRoute(
           builder: (context) => isMarkdown
               ? MarkdownScreen(
-                  content: content.toString(),
+                  content: formattedContent,
                   releaseVersion: _selectedReleasePage!,
                 )
               : PlainTextScreen(
-                  content: content.toString(),
+                  content: formattedContent,
                   releaseVersion: _selectedReleasePage!,
                 ),
         ),


### PR DESCRIPTION
This pull request introduces significant enhancements to the release notes feature by adding methods for formatting the release notes in both Markdown and plain text formats. Additionally, it updates the home screen to utilize these new formatting methods.

### Enhancements to release notes formatting:

* [`lib/models/release_notes_model.dart`](diffhunk://#diff-069f4e88075ee8ea48a65efaba6950b5e4d755df2d35d4a8e5043a9dae2afda9R126-R205): Added `toMarkdown` and `toPlainText` methods to the `ReleaseNotesModel` class to generate formatted release notes in Markdown and plain text formats, respectively.

### Updates to home screen:

* [`lib/screens/home_screen.dart`](diffhunk://#diff-935e56a557f0ab902a679f47de66345d9f47058bccb96f870e6383d19e2c86ddL36-R54): Modified the `_HomeScreenState` class to use the new `toMarkdown` and `toPlainText` methods for displaying release notes in the appropriate format based on user selection.…sModel class