### PR TITLE
Add the copy feature

### DIFF
--- a/lib/screens/markdown_screen.dart
+++ b/lib/screens/markdown_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class MarkdownScreen extends StatelessWidget {
   final String content;
@@ -12,8 +13,6 @@ class MarkdownScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print('MarkdownScreen build');
-    print(content);
     return Scaffold(
       appBar: AppBar(
         title: Text('Markdown View - $releaseVersion'),
@@ -21,6 +20,23 @@ class MarkdownScreen extends StatelessWidget {
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.of(context).pop(),
         ),
+        // Add this actions property to the AppBar
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.copy),
+            tooltip: 'Copy to clipboard', // Optional tooltip
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: content)).then((_) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Content copied to clipboard'),
+                    duration: Duration(seconds: 2),
+                  ),
+                );
+              });
+            },
+          ),
+        ],
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),

--- a/lib/screens/plain_text_screen.dart
+++ b/lib/screens/plain_text_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class PlainTextScreen extends StatelessWidget {
   final String content;
@@ -12,8 +13,6 @@ class PlainTextScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print('PlainTextScreen build');
-    print(content);
     return Scaffold(
       appBar: AppBar(
         title: Text('Plain Text View - $releaseVersion'),
@@ -21,6 +20,23 @@ class PlainTextScreen extends StatelessWidget {
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.of(context).pop(),
         ),
+        // Add this actions property to the AppBar
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.copy),
+            tooltip: 'Copy to clipboard', // Optional tooltip
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: content)).then((_) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Content copied to clipboard'),
+                    duration: Duration(seconds: 2),
+                  ),
+                );
+              });
+            },
+          ),
+        ],
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),


### PR DESCRIPTION
This pull request includes changes to the `MarkdownScreen` and `PlainTextScreen` components to enhance their functionality by adding a copy-to-clipboard feature. The most important changes include importing the required `flutter/services.dart` package and adding an `IconButton` to the `AppBar` for copying content to the clipboard.

Enhancements to `MarkdownScreen` and `PlainTextScreen`:

* [`lib/screens/markdown_screen.dart`](diffhunk://#diff-8f41b76a20c8e8cf632cef2bb8c0514223c9ea56683721af78cfcfa3422fc775R2): Imported the `flutter/services.dart` package to enable clipboard functionality.
* [`lib/screens/markdown_screen.dart`](diffhunk://#diff-8f41b76a20c8e8cf632cef2bb8c0514223c9ea56683721af78cfcfa3422fc775L15-R39): Added an `IconButton` to the `AppBar` that copies the content to the clipboard and shows a `SnackBar` confirmation.
* [`lib/screens/plain_text_screen.dart`](diffhunk://#diff-c553abf24cdb0c99228249a7018066325883d4c89ff83259a17618b50d3778baR2): Imported the `flutter/services.dart` package to enable clipboard functionality.
* [`lib/screens/plain_text_screen.dart`](diffhunk://#diff-c553abf24cdb0c99228249a7018066325883d4c89ff83259a17618b50d3778baL15-R39): Added an `IconButton` to the `AppBar` that copies the content to the clipboard and shows a `SnackBar` confirmation.